### PR TITLE
Correcting typo in prompt/comment

### DIFF
--- a/nested.rb
+++ b/nested.rb
@@ -1,6 +1,6 @@
 
 def hopper
-	programmer_hash = 
+	programmer_hash =
  		{
         :grace_hopper => {
           :known_for => "COBOL",
@@ -21,8 +21,8 @@ end
 
 def alan_kay_is_known_for
 	# What combination of keys would you use to return the value of the :known_for key of :alan_kay?
-	
-	programmer_hash = 
+
+	programmer_hash =
  		{
         :grace_hopper => {
           :known_for => "COBOL",
@@ -40,7 +40,7 @@ def alan_kay_is_known_for
 end
 
 def dennis_ritchies_language
-	programmer_hash = 
+	programmer_hash =
  		{
         :grace_hopper => {
           :known_for => "COBOL",
@@ -61,10 +61,10 @@ def adding_matz
 # add the following information to the top level of programmer_hash
 # :yukihiro_matsumoto => {
 #   :known_for => "Ruby",
-#    :languages => ["LISP, C"]
+#    :languages => ["LISP", "C"]
 # }
 
-	programmer_hash = 
+	programmer_hash =
  		{
         :grace_hopper => {
           :known_for => "COBOL",
@@ -80,11 +80,11 @@ def adding_matz
         }
      }
 
-    
+
 end
 
 def changing_alan
-	programmer_hash = 
+	programmer_hash =
  		{
         :grace_hopper => {
           :known_for => "COBOL",
@@ -99,14 +99,14 @@ def changing_alan
           :languages => ["C"]
         }
      }
-     #change what Alan Kay is :known_for to the value of the alans_new_info variable. 
+     #change what Alan Kay is :known_for to the value of the alans_new_info variable.
      alans_new_info = "GUI"
-     
-     
+
+
 end
 
 def adding_to_dennis
-	programmer_hash = 
+	programmer_hash =
  		{
         :grace_hopper => {
           :known_for => "COBOL",


### PR DESCRIPTION
Minor correction to prompt/comment on line 64. Original text would have yielded a single item array with the text "LISP, C" as opposed to a two item array containing items "LISP" and "C".

Other changes are non-substantive white space erasure.